### PR TITLE
Snap 981

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -56,7 +56,7 @@ object SQLConf {
   val WAREHOUSE_PATH = SQLConfigBuilder("spark.sql.warehouse.dir")
     .doc("The default location for managed databases and tables.")
     .stringConf
-    .createWithDefault("${system:user.dir}/spark-warehouse")
+    .createWithDefault("file:${system:user.dir}/spark-warehouse")
 
   val OPTIMIZER_MAX_ITERATIONS = SQLConfigBuilder("spark.sql.optimizer.maxIterations")
     .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?

SNAP-981 Pertains to SPARK-15565. The default value of spark.sql.warehouse.dir is System.getProperty("user.dir")/warehouse. Since System.getProperty("user.dir") is a local dir, we should explicitly set the scheme to local filesystem.  Took it from PR https://github.com/apache/spark/pull/13348
## How was this patch tested?

manual tests, precheckin
