### PR TITLE
[SNAPPYDATA] Add a sql conf property to enforce rendering of STRING type as CLOB.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -553,6 +553,13 @@ object SQLConf {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefault(10L)
 
+  val STRING_AS_CLOB = SQLConfigBuilder("spark.sql.stringAsClob")
+      .internal()
+      .doc("Whether STRING type should be rendered as CLOB." +
+          " Default is false, which treats STRING as VARCHAR with max size.")
+      .booleanConf
+      .createWithDefault(false)
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
@@ -690,6 +697,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   def variableSubstituteEnabled: Boolean = getConf(VARIABLE_SUBSTITUTE_ENABLED)
 
   def variableSubstituteDepth: Int = getConf(VARIABLE_SUBSTITUTE_DEPTH)
+
+  def stringAsClob: Boolean = getConf(STRING_AS_CLOB)
 
   def warehousePath: String = {
     new Path(getConf(WAREHOUSE_PATH).replace("${system:user.dir}",


### PR DESCRIPTION
## What changes were proposed in this pull request?

[SNAPPYDATA] SNAP-735 Add a sql conf property to enforce rendering of STRING type as CLOB.
By default, it is treated as VARCHAR with max size.
## How was this patch tested?

Added a unit test. See https://github.com/SnappyDataInc/snappydata/pull/353/
