### PR TITLE
[SNAP-966] Prefer conversions to date/timestamp and not strings

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -316,19 +316,19 @@ object TypeCoercion {
       // This behaves as a user would expect because timestamp strings sort lexicographically.
       // i.e. TimeStamp(2013-01-01 00:00 ...) < "2014" = true
       case p @ BinaryComparison(left @ StringType(), right @ DateType()) =>
-        p.makeCopy(Array(left, Cast(right, StringType)))
+        p.makeCopy(Array(Cast(left, DateType), right))
       case p @ BinaryComparison(left @ DateType(), right @ StringType()) =>
-        p.makeCopy(Array(Cast(left, StringType), right))
+        p.makeCopy(Array(left, Cast(right, DateType)))
       case p @ BinaryComparison(left @ StringType(), right @ TimestampType()) =>
-        p.makeCopy(Array(left, Cast(right, StringType)))
+        p.makeCopy(Array(Cast(left, TimestampType), right))
       case p @ BinaryComparison(left @ TimestampType(), right @ StringType()) =>
-        p.makeCopy(Array(Cast(left, StringType), right))
+        p.makeCopy(Array(left, Cast(right, TimestampType)))
 
       // Comparisons between dates and timestamps.
       case p @ BinaryComparison(left @ TimestampType(), right @ DateType()) =>
-        p.makeCopy(Array(Cast(left, StringType), Cast(right, StringType)))
+        p.makeCopy(Array(left, Cast(right, TimestampType)))
       case p @ BinaryComparison(left @ DateType(), right @ TimestampType()) =>
-        p.makeCopy(Array(Cast(left, StringType), Cast(right, StringType)))
+        p.makeCopy(Array(Cast(left, TimestampType), right))
 
       // Checking NullType
       case p @ BinaryComparison(left @ StringType(), right @ NullType()) =>
@@ -342,13 +342,13 @@ object TypeCoercion {
         p.makeCopy(Array(left, Cast(right, DoubleType)))
 
       case i @ In(a @ DateType(), b) if b.forall(_.dataType == StringType) =>
-        i.makeCopy(Array(Cast(a, StringType), b))
+        i.makeCopy(Array(a, b.map(Cast(_, DateType))))
       case i @ In(a @ TimestampType(), b) if b.forall(_.dataType == StringType) =>
         i.makeCopy(Array(a, b.map(Cast(_, TimestampType))))
       case i @ In(a @ DateType(), b) if b.forall(_.dataType == TimestampType) =>
-        i.makeCopy(Array(Cast(a, StringType), b.map(Cast(_, StringType))))
+        i.makeCopy(Array(Cast(a, TimestampType), b))
       case i @ In(a @ TimestampType(), b) if b.forall(_.dataType == DateType) =>
-        i.makeCopy(Array(Cast(a, StringType), b.map(Cast(_, StringType))))
+        i.makeCopy(Array(a, b.map(Cast(_, TimestampType))))
 
       case Sum(e @ StringType()) => Sum(Cast(e, DoubleType))
       case Average(e @ StringType()) => Average(Cast(e, DoubleType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -312,9 +312,8 @@ object TypeCoercion {
       case p @ Equality(left @ TimestampType(), right @ StringType()) =>
         p.makeCopy(Array(left, Cast(right, TimestampType)))
 
-      // We should cast all relative timestamp/date/string comparison into string comparisons
-      // This behaves as a user would expect because timestamp strings sort lexicographically.
-      // i.e. TimeStamp(2013-01-01 00:00 ...) < "2014" = true
+      // Parsing of partial dates/timestamps has been added for SPARK-8995 hence
+      // converting strings to dates/timestamps.
       case p @ BinaryComparison(left @ StringType(), right @ DateType()) =>
         p.makeCopy(Array(Cast(left, DateType), right))
       case p @ BinaryComparison(left @ DateType(), right @ StringType()) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

SPARK-8420 changed the behaviour to convert to strings for all date/timestamp comparisons if any side is a string to handle partial dates.

However, SPARK-8995 added support for partial date string parsing making SPARK-8420 redundant. This PR chooses the most efficient and accurate conversion route for all cases involving dates and timestamps.
- for all cases of implicit casts, convert to date or timestamp values instead of string when one side is a string
- likewise when one side is a timestamp and other date then both are being converted to string; now convert date to timestamp
## How was this patch tested?

Running upstream spark branch-2.0 tests with these changes.

This PR needs to be proposed upstream.
