### PR TITLE
[SNAP-1034] Optimizations at Spark layer as seen in profiling

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2036,6 +2036,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     dagScheduler.cancelStage(stageId)
   }
 
+  private val cleanerMap = new ConcurrentHashMap[Class[_], java.lang.Boolean]()
+
   /**
    * Clean a closure to make it ready to serialized and send to tasks
    * (removes unreferenced variables in $outer's, updates REPL variables)
@@ -2049,8 +2051,27 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    *   serializable
    */
   private[spark] def clean[F <: AnyRef](f: F, checkSerializable: Boolean = true): F = {
-    ClosureCleaner.clean(f, checkSerializable)
-    f
+    val clazz = f.getClass
+    val v: java.lang.Boolean = cleanerMap.get(clazz)
+    if (v != null) {
+      if (v.booleanValue()) f
+      else {
+        ClosureCleaner.clean(f, checkSerializable)
+        f
+      }
+    } else {
+      // check if function is serializable without clean
+      try {
+        env.closureSerializer.newInstance().serialize(f.asInstanceOf[AnyRef])
+        cleanerMap.put(clazz, java.lang.Boolean.TRUE)
+        f
+      } catch {
+        case _: Exception =>
+          cleanerMap.put(clazz, java.lang.Boolean.FALSE)
+          ClosureCleaner.clean(f, checkSerializable)
+          f
+      }
+    }
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
@@ -149,6 +149,23 @@ class OpenHashMap[K : ClassTag, @specialized(Long, Int, Double) V: ClassTag](
     }
   }
 
+  def clear() {
+    // first clear the values array and value for null key
+    val bitSet = _keySet.getBitSet
+    val nullV = null.asInstanceOf[V]
+    val values = _values
+    var pos = bitSet.nextSetBit(0)
+    while (pos >= 0) {
+      values(pos) = nullV
+      pos = bitSet.nextSetBit(pos + 1)
+    }
+    haveNullValue = false
+    nullValue = nullV
+    _oldValues = null
+    // next clear the key set
+    _keySet.clear()
+  }
+
   // The following member variables are declared as protected instead of private for the
   // specialization to work (specialized class extends the non-specialized one and needs access
   // to the "private" variables).

--- a/core/src/main/scala/org/apache/spark/util/collection/OpenHashSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/OpenHashSet.scala
@@ -212,6 +212,12 @@ class OpenHashSet[@specialized(Long, Int) T: ClassTag](
    */
   def nextPos(fromPos: Int): Int = _bitset.nextSetBit(fromPos)
 
+  def clear() {
+    _data = new Array[T](_capacity)
+    _bitset.clear()
+    _size = 0
+  }
+
   /**
    * Double the table's size and re-hash everything. We are not really using k, but it is declared
    * so Scala compiler can specialize this method (which leads to calling the specialized version

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
@@ -53,9 +53,15 @@ case class Average(child: Expression) extends DeclarativeAggregate {
   }
 
   private lazy val sum = AttributeReference("sum", sumDataType)()
-  private lazy val count = AttributeReference("count", LongType)()
+  private lazy val count = AttributeReference("count", LongType, nullable = false)()
 
   override lazy val aggBufferAttributes = sum :: count :: Nil
+
+  override lazy val aggBufferWithKeyAttributes: Seq[AttributeReference] = {
+    if (child.nullable) aggBufferAttributes
+    else sum.copy(nullable = false)(sum.exprId, sum.qualifier,
+      sum.isGenerated) :: count :: Nil
+  }
 
   override lazy val initialValues = Seq(
     /* sum = */ Cast(Literal(0), sumDataType),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
@@ -58,9 +58,16 @@ case class First(child: Expression, ignoreNullsExpr: Expression) extends Declara
 
   private lazy val first = AttributeReference("first", child.dataType)()
 
-  private lazy val valueSet = AttributeReference("valueSet", BooleanType)()
+  private lazy val valueSet = AttributeReference("valueSet", BooleanType,
+    nullable = false)()
 
   override lazy val aggBufferAttributes: Seq[AttributeReference] = first :: valueSet :: Nil
+
+  override lazy val aggBufferWithKeyAttributes: Seq[AttributeReference] = {
+    if (child.nullable) aggBufferAttributes
+    else first.copy(nullable = false)(first.exprId, first.qualifier,
+      first.isGenerated) :: valueSet :: Nil
+  }
 
   override lazy val initialValues: Seq[Literal] = Seq(
     /* first = */ Literal.create(null, child.dataType),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
@@ -57,6 +57,12 @@ case class Last(child: Expression, ignoreNullsExpr: Expression) extends Declarat
 
   override lazy val aggBufferAttributes: Seq[AttributeReference] = last :: Nil
 
+  override lazy val aggBufferWithKeyAttributes: Seq[AttributeReference] = {
+    if (child.nullable) aggBufferAttributes
+    else last.copy(nullable = false)(last.exprId, last.qualifier,
+      last.isGenerated) :: Nil
+  }
+
   override lazy val initialValues: Seq[Literal] = Seq(
     /* last = */ Literal.create(null, child.dataType)
   )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Max.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Max.scala
@@ -43,6 +43,12 @@ case class Max(child: Expression) extends DeclarativeAggregate {
 
   override lazy val aggBufferAttributes: Seq[AttributeReference] = max :: Nil
 
+  override lazy val aggBufferWithKeyAttributes: Seq[AttributeReference] = {
+    if (child.nullable) aggBufferAttributes
+    else max.copy(nullable = false)(max.exprId, max.qualifier,
+      max.isGenerated) :: Nil
+  }
+
   override lazy val initialValues: Seq[Literal] = Seq(
     /* max = */ Literal.create(null, child.dataType)
   )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Min.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Min.scala
@@ -43,6 +43,12 @@ case class Min(child: Expression) extends DeclarativeAggregate {
 
   override lazy val aggBufferAttributes: Seq[AttributeReference] = min :: Nil
 
+  override lazy val aggBufferWithKeyAttributes: Seq[AttributeReference] = {
+    if (child.nullable) aggBufferAttributes
+    else min.copy(nullable = false)(min.exprId, min.qualifier,
+      min.isGenerated) :: Nil
+  }
+
   override lazy val initialValues: Seq[Expression] = Seq(
     /* min = */ Literal.create(null, child.dataType)
   )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -53,6 +53,12 @@ case class Sum(child: Expression) extends DeclarativeAggregate {
 
   override lazy val aggBufferAttributes = sum :: Nil
 
+  override lazy val aggBufferWithKeyAttributes: Seq[AttributeReference] = {
+    if (child.nullable) aggBufferAttributes
+    else sum.copy(nullable = false)(sum.exprId, sum.qualifier,
+      sum.isGenerated) :: Nil
+  }
+
   override lazy val initialValues: Seq[Expression] = Seq(
     /* sum = */ Literal.create(null, sumDataType)
   )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -184,6 +184,9 @@ sealed abstract class AggregateFunction extends Expression with ImplicitCastInpu
   /** Attributes of fields in aggBufferSchema. */
   def aggBufferAttributes: Seq[AttributeReference]
 
+  /** Attributes of fields in aggBufferSchema used for group by. */
+  def aggBufferWithKeyAttributes: Seq[AttributeReference] = aggBufferAttributes
+
   /**
    * Attributes of fields in input aggregation buffers (immutable aggregation buffers that are
    * merged with mutable aggregation buffers in the merge() function or merge expressions).

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/compressionSchemes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/compressionSchemes.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{MutableRow, SpecificMutableRow}
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.types._
+import org.apache.spark.util.collection.OpenHashMap
 
 
 private[columnar] case object PassThrough extends CompressionScheme {
@@ -208,7 +209,7 @@ private[columnar] case object DictionaryEncoding extends CompressionScheme {
     private var values = new mutable.ArrayBuffer[T#InternalType](1024)
 
     // The dictionary that maps a value to the encoded short integer.
-    private val dictionary = mutable.HashMap.empty[Any, Short]
+    private val dictionary = new OpenHashMap[Any, Short]
 
     // Size of the serialized dictionary in bytes. Initialized to 4 since we need at least an `Int`
     // to store dictionary element count.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -134,9 +134,9 @@ trait HashJoin {
       joinRow.withLeft(srow)
       val matches = hashedRelation.get(joinKeys(srow))
       if (matches != null) {
-        matches.map(joinRow.withRight(_)).filter(boundCondition)
+        matches.map(joinRow.withRight).filter(boundCondition)
       } else {
-        Seq.empty
+        Iterator.empty
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -24,7 +24,8 @@ import org.apache.spark.scheduler.AccumulableInfo
 import org.apache.spark.util.{AccumulatorContext, AccumulatorV2, Utils}
 
 
-class SQLMetric(val metricType: String, initValue: Long = 0L) extends AccumulatorV2[Long, Long] {
+final class SQLMetric(val metricType: String, initValue: Long = 0L)
+    extends AccumulatorV2[Long, Long] {
   // This is a workaround for SPARK-11013.
   // We may use -1 as initial value of the accumulator, if the accumulator is valid, we will
   // update it at the end of task and the value will be at least 0. Then we can filter out the -1

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -280,7 +280,7 @@ private[spark] object HiveUtils extends Logging {
         throw new IllegalArgumentException(
           "Builtin jars can only be used when hive execution version == hive metastore version. " +
             s"Execution: $hiveExecutionVersion != Metastore: $hiveMetastoreVersion. " +
-            "Specify a vaild path to the correct hive jars using $HIVE_METASTORE_JARS " +
+            s"Specify a vaild path to the correct hive jars using $HIVE_METASTORE_JARS " +
             s"or change ${HIVE_METASTORE_VERSION.key} to $hiveExecutionVersion.")
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
- added a aggBufferWithKeyAttributes to aggregates to be used to avoid nullable checks in generated code in aggregate buffers used in HashAggregateExec (if aggregate is on zero rows, then there will be no row in the map)
- use OpenHashMap in DictionaryEncoding which is faster than normal hash map; added clear methods to OpenHashMap/OpenHashSet for reuse
- temp change to use a local cache for ClosureCleaner to avoid cleaning closures that can be serialized as is
- minor correction in the string in HiveUtils

Note that the closure cleaner change is just a temporary hack for testing. It will be turned into a proper shape by caching the steps for cleaning of each class, if any, and then applying those steps in order (this strategy may not work very well for polymorphic types but user can take care explicitly for such special cases). This is being tracked in a separate JIRA.
## How was this patch tested?

Applied and tested with upstream spark branch-2.0
