### PR TITLE
[SNAP-1192] correct offsetInBytes calculation

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -550,7 +550,7 @@ public final class UnsafeRow extends MutableRow implements Externalizable, KryoS
    */
   public void writeToStream(OutputStream out, byte[] writeBuffer) throws IOException {
     if (baseObject instanceof byte[]) {
-      int offsetInByteArray = (int) (Platform.BYTE_ARRAY_OFFSET - baseOffset);
+      int offsetInByteArray = (int) (baseOffset - Platform.BYTE_ARRAY_OFFSET);
       out.write((byte[]) baseObject, offsetInByteArray, sizeInBytes);
     } else {
       int dataRemaining = sizeInBytes;


### PR DESCRIPTION
## What changes were proposed in this pull request?

offsetInBytes in UnsafeRow.writeToStream should be "baseOffset - Platform.BYTE_ARRAY_OFFSET" instead of "Platform.BYTE_ARRAY_OFFSET - baseOffset"

## How was this patch tested?

precheckin
