### PR TITLE
[SNAP-1194] explicit addLong/longValue methods in SQLMetrics

### DIFF
--- a/assembly/build.gradle
+++ b/assembly/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   compile project(subprojectBase + 'snappy-spark-streaming_' + scalaBinaryVersion)
   compile project(subprojectBase + 'snappy-spark-streaming-kafka-0.8_' + scalaBinaryVersion)
   compile project(subprojectBase + 'snappy-spark-streaming-kafka-0.10_' + scalaBinaryVersion)
+  compile project(subprojectBase + 'snappy-spark-sql-kafka-0.10_' + scalaBinaryVersion)
   compile project(subprojectBase + 'snappy-spark-yarn_' + scalaBinaryVersion)
   compile project(subprojectBase + 'snappy-spark-mllib_' + scalaBinaryVersion)
   compile project(subprojectBase + 'snappy-spark-graphx_' + scalaBinaryVersion)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -129,7 +129,7 @@ dependencies {
   }
   compile group: 'org.apache.ivy', name: 'ivy', version: '2.4.0'
   compile group: 'oro', name: 'oro', version: '2.0.8'
-  compile(group: 'net.razorvine', name: 'pyrolite', version: '4.9') {
+  compile(group: 'net.razorvine', name: 'pyrolite', version: '4.13') {
     exclude(group: 'net.razorvine', module: 'serpent')
   }
   compile group: 'net.sf.py4j', name: 'py4j', version: '0.10.1'

--- a/external/kafka-0-10-sql/build.gradle
+++ b/external/kafka-0-10-sql/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   provided project(subprojectBase + 'snappy-spark-catalyst_' + scalaBinaryVersion)
   provided project(subprojectBase + 'snappy-spark-sql_' + scalaBinaryVersion)
 
-  compile group: 'org.apache.kafka', name: 'kafka-clients_' + scalaBinaryVersion, version: '0.10.0.1'
+  compile group: 'org.apache.kafka', name: 'kafka-clients', version: '0.10.0.1'
 
   testCompile project(path: subprojectBase + 'snappy-spark-core_' + scalaBinaryVersion, configuration: 'testOutput')
   testCompile project(path: subprojectBase + 'snappy-spark-catalyst_' + scalaBinaryVersion, configuration: 'testOutput')

--- a/external/kafka-0-10-sql/build.gradle
+++ b/external/kafka-0-10-sql/build.gradle
@@ -15,21 +15,19 @@
  * LICENSE file.
  */
 
-description = 'Spark Integration for Kafka 0.10'
+description = 'Kafka 0.10 Source for Structured Streaming'
 
 dependencies {
   compile project(subprojectBase + 'snappy-spark-tags_' + scalaBinaryVersion)
   provided project(subprojectBase + 'snappy-spark-core_' + scalaBinaryVersion)
-  provided project(subprojectBase + 'snappy-spark-streaming_' + scalaBinaryVersion)
+  provided project(subprojectBase + 'snappy-spark-catalyst_' + scalaBinaryVersion)
+  provided project(subprojectBase + 'snappy-spark-sql_' + scalaBinaryVersion)
 
-  compile(group: 'org.apache.kafka', name: 'kafka_' + scalaBinaryVersion, version: '0.10.0.1') {
-    exclude(group: 'com.sun.jmx', module: 'jmxri')
-    exclude(group: 'com.sun.jdmk ', module: 'jmxtools')
-    exclude(group: 'net.sf.jopt-simple', module: 'jopt-simple')
-    exclude(group: 'org.slf4j', module: 'slf4j-simple')
-    exclude(group: 'org.apache.zookeeper', module: 'zookeeper')
-  }
+  compile group: 'org.apache.kafka', name: 'kafka-clients_' + scalaBinaryVersion, version: '0.10.0.1'
 
   testCompile project(path: subprojectBase + 'snappy-spark-core_' + scalaBinaryVersion, configuration: 'testOutput')
+  testCompile project(path: subprojectBase + 'snappy-spark-catalyst_' + scalaBinaryVersion, configuration: 'testOutput')
+  testCompile project(path: subprojectBase + 'snappy-spark-sql_' + scalaBinaryVersion, configuration: 'testOutput')
+  testCompile group: 'org.apache.kafka', name: 'kafka_' + scalaBinaryVersion, version: '0.10.0.1'
   testCompile group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '3.2'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,7 @@ include ':snappy-spark-streaming-flume_' + scalaBinaryVersion
 include ':snappy-spark-streaming-flume-sink_' + scalaBinaryVersion
 include ':snappy-spark-streaming-kafka-0.8_' + scalaBinaryVersion
 include ':snappy-spark-streaming-kafka-0.10_' + scalaBinaryVersion
+include ':snappy-spark-sql-kafka-0.10_' + scalaBinaryVersion
 include ':snappy-spark-examples_' + scalaBinaryVersion
 include ':snappy-spark-repl_' + scalaBinaryVersion
 include ':snappy-spark-launcher_' + scalaBinaryVersion
@@ -67,6 +68,7 @@ project(':snappy-spark-streaming-flume_' + scalaBinaryVersion).projectDir = "$ro
 project(':snappy-spark-streaming-flume-sink_' + scalaBinaryVersion).projectDir = "$rootDir/external/flume-sink" as File
 project(':snappy-spark-streaming-kafka-0.8_' + scalaBinaryVersion).projectDir = "$rootDir/external/kafka-0-8" as File
 project(':snappy-spark-streaming-kafka-0.10_' + scalaBinaryVersion).projectDir = "$rootDir/external/kafka-0-10" as File
+project(':snappy-spark-sql-kafka-0.10_' + scalaBinaryVersion).projectDir = "$rootDir/external/kafka-0-10-sql" as File
 project(':snappy-spark-examples_' + scalaBinaryVersion).projectDir = "$rootDir/examples" as File
 project(':snappy-spark-repl_' + scalaBinaryVersion).projectDir = "$rootDir/repl" as File
 project(':snappy-spark-launcher_' + scalaBinaryVersion).projectDir = "$rootDir/launcher" as File

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -196,7 +196,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
     s"""
        |$generated
        |$nullChecks
-       |$numOutput.add(1);
+       |$numOutput.addLong(1);
        |${consume(ctx, resultVars)}
      """.stripMargin
   }
@@ -289,7 +289,7 @@ case class SampleExec(
       s"""
          | int $samplingCount = $sampler.sample();
          | while ($samplingCount-- > 0) {
-         |   $numOutput.add(1);
+         |   $numOutput.addLong(1);
          |   ${consume(ctx, input)}
          | }
        """.stripMargin.trim
@@ -303,7 +303,7 @@ case class SampleExec(
 
       s"""
          | if ($sampler.sample() == 0) continue;
-         | $numOutput.add(1);
+         | $numOutput.addLong(1);
          | ${consume(ctx, input)}
        """.stripMargin.trim
     }
@@ -384,7 +384,7 @@ case class RangeExec(range: org.apache.spark.sql.catalyst.plans.logical.Range)
         |     $partitionEnd = end.longValue();
         |   }
         |
-        |   $numOutput.add(($partitionEnd - $number) / ${step}L);
+        |   $numOutput.addLong(($partitionEnd - $number) / ${step}L);
         | }
        """.stripMargin)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -55,6 +55,11 @@ final class SQLMetric(var metricType: String, initValue: Long = 0L)
 
   override def add(v: Long): Unit = _value += v
 
+  // avoid the runtime generic Object conversion of add(), value()
+  final def addLong(v: Long): Unit = _value += v
+
+  final def longValue: Long = _value
+
   def +=(v: Long): Unit = _value += v
 
   override def value: Long = _value


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add methods taking primitive values help in avoiding boxing/unboxing overhead as well as better chance of being inlined by JVM.

## How was this patch tested?

snappydata precheckin
