### PR TITLE
[SNAP-1202] Reduce serialization overheads of biggest contributors in queries

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -51,7 +51,6 @@ import scala.reflect.{classTag, ClassTag}
 import scala.util.control.NonFatal
 
 import com.google.common.collect.MapMaker
-import org.apache.commons.lang3.SerializationUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.io.{ArrayWritable, BooleanWritable, BytesWritable, DoubleWritable, FloatWritable, IntWritable, LongWritable, NullWritable, Text, Writable}
@@ -348,7 +347,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     override protected def childValue(parent: Properties): Properties = {
       // Note: make a clone such that changes in the parent properties aren't reflected in
       // the those of the children threads, which has confusing semantics (SPARK-10563).
-      SerializationUtils.clone(parent)
+      Utils.cloneProperties(parent)
     }
     override protected def initialValue(): Properties = new Properties()
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -30,8 +30,6 @@ import scala.language.existentials
 import scala.language.postfixOps
 import scala.util.control.NonFatal
 
-import org.apache.commons.lang3.SerializationUtils
-
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.executor.TaskMetrics
@@ -588,7 +586,7 @@ class DAGScheduler(
     val waiter = new JobWaiter(this, jobId, partitions.size, resultHandler)
     eventProcessLoop.post(JobSubmitted(
       jobId, rdd, func2, partitions.toArray, callSite, waiter,
-      SerializationUtils.clone(properties)))
+      Utils.cloneProperties(properties)))
     waiter
   }
 
@@ -658,7 +656,7 @@ class DAGScheduler(
     val partitions = (0 until rdd.partitions.length).toArray
     val jobId = nextJobId.getAndIncrement()
     eventProcessLoop.post(JobSubmitted(
-      jobId, rdd, func2, partitions, callSite, listener, SerializationUtils.clone(properties)))
+      jobId, rdd, func2, partitions, callSite, listener, Utils.cloneProperties(properties)))
     listener.awaitResult()    // Will throw an exception if the job fails
   }
 
@@ -693,7 +691,7 @@ class DAGScheduler(
     // the map output tracker and some node failures had caused the output statistics to be lost.
     val waiter = new JobWaiter(this, jobId, 1, (i: Int, r: MapOutputStatistics) => callback(r))
     eventProcessLoop.post(MapStageSubmitted(
-      jobId, dependency, callSite, waiter, SerializationUtils.clone(properties)))
+      jobId, dependency, callSite, waiter, Utils.cloneProperties(properties)))
     waiter
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -253,9 +253,17 @@ private[spark] object Task {
     }
 
     // Write the task properties separately so it is available before full task deserialization.
-    val propBytes = Utils.serialize(task.localProperties)
-    dataOut.writeInt(propBytes.length)
-    dataOut.write(propBytes)
+    val props = task.localProperties
+    val numProps = props.size()
+    dataOut.writeInt(numProps)
+    if (numProps > 0) {
+      val keys = props.keys()
+      while (keys.hasMoreElements) {
+        val key = keys.nextElement().asInstanceOf[String]
+        dataOut.writeUTF(key)
+        dataOut.writeUTF(props.getProperty(key))
+      }
+    }
 
     // Write the task itself and finish
     dataOut.flush()
@@ -292,10 +300,13 @@ private[spark] object Task {
       taskJars(dataIn.readUTF()) = dataIn.readLong()
     }
 
-    val propLength = dataIn.readInt()
-    val propBytes = new Array[Byte](propLength)
-    dataIn.readFully(propBytes, 0, propLength)
-    val taskProps = Utils.deserialize[Properties](propBytes)
+    val taskProps = new Properties
+    var numProps = dataIn.readInt()
+    while (numProps > 0) {
+      val key = dataIn.readUTF()
+      taskProps.setProperty(key, dataIn.readUTF())
+      numProps -= 1
+    }
 
     // Create a sub-buffer for the rest of the data, which is the serialized Task object
     val subBuffer = serializedTask.slice()  // ByteBufferInputStream will have read just up to task

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -148,6 +148,40 @@ private[spark] object Utils extends Logging {
   /** Shorthand for calling truncatedString() without start or end strings. */
   def truncatedString[T](seq: Seq[T], sep: String): String = truncatedString(seq, "", sep, "")
 
+  def cloneProperties(properties: Properties,
+      withDefaults: Boolean = false): Properties = {
+    val newProperties = new Properties()
+    // first put the keys other than the ones only in defaults
+    var numStringKeys = 0
+    if (!properties.isEmpty) {
+      val entries = properties.entrySet().iterator()
+      while (entries.hasNext) {
+        val entry = entries.next
+        val key = entry.getKey
+        if (withDefaults && key.isInstanceOf[String]) {
+          numStringKeys += 1
+        }
+        newProperties.put(key, entry.getValue)
+      }
+    }
+    if (withDefaults) {
+      // list the string properties if there are any that are only in defaults
+      val stringKeys = properties.stringPropertyNames()
+      // check if any extra keys in defaults exist (only String keys are useful
+      //   since those are the only ones that can be queried)
+      if (stringKeys.size() > numStringKeys) {
+        val iterator = stringKeys.iterator()
+        while (iterator.hasNext) {
+          val key = iterator.next()
+          if (!newProperties.contains(key)) {
+            newProperties.setProperty(key, properties.getProperty(key))
+          }
+        }
+      }
+    }
+    newProperties
+  }
+
   /** Serialize an object using Java serialization */
   def serialize[T](o: T): Array[Byte] = {
     val bos = new ByteArrayOutputStream()

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -168,7 +168,7 @@ private[spark] object Utils extends Logging {
       // list the string properties if there are any that are only in defaults
       val stringKeys = properties.stringPropertyNames()
       // check if any extra keys in defaults exist (only String keys are useful
-      //   since those are the only ones that can be queried)
+      //   since those are the only ones that can be queried from defaults)
       if (stringKeys.size() > numStringKeys) {
         val iterator = stringKeys.iterator()
         while (iterator.hasNext) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -785,12 +785,23 @@ abstract class GeneratedClass {
  */
 class CodeAndComment(val body: String, val comment: collection.Map[String, String])
   extends Serializable {
+
+  private[sql] var hash: Int = 0
+
   override def equals(that: Any): Boolean = that match {
     case t: CodeAndComment if t.body == body => true
     case _ => false
   }
 
-  override def hashCode(): Int = body.hashCode
+  // noinspection HashCodeUsesVar
+  override def hashCode(): Int = {
+    val h = hash
+    if (h != 0) h
+    else {
+      hash = body.hashCode
+      hash
+    }
+  }
 }
 
 /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -26,7 +26,6 @@ import scala.collection.mutable.Queue
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
-import org.apache.commons.lang3.SerializationUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{BytesWritable, LongWritable, Text}
@@ -579,7 +578,7 @@ class StreamingContext private[streaming] (
               sparkContext.setCallSite(startSite.get)
               sparkContext.clearJobGroup()
               sparkContext.setLocalProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "false")
-              savedProperties.set(SerializationUtils.clone(sparkContext.localProperties.get()))
+              savedProperties.set(Utils.cloneProperties(sparkContext.localProperties.get()))
               scheduler.start()
             }
             state = StreamingContextState.ACTIVE

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -22,14 +22,12 @@ import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 import scala.collection.JavaConverters._
 import scala.util.Failure
 
-import org.apache.commons.lang3.SerializationUtils
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.{PairRDDFunctions, RDD}
 import org.apache.spark.streaming._
 import org.apache.spark.streaming.api.python.PythonDStream
 import org.apache.spark.streaming.ui.UIUtils
-import org.apache.spark.util.{EventLoop, ThreadUtils}
+import org.apache.spark.util.{EventLoop, ThreadUtils, Utils}
 
 
 private[scheduler] sealed trait JobSchedulerEvent
@@ -220,7 +218,7 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
     def run() {
       val oldProps = ssc.sparkContext.getLocalProperties
       try {
-        ssc.sparkContext.setLocalProperties(SerializationUtils.clone(ssc.savedProperties.get()))
+        ssc.sparkContext.setLocalProperties(Utils.cloneProperties(ssc.savedProperties.get()))
         val formattedTime = UIUtils.formatBatchTime(
           job.time.milliseconds, ssc.graph.batchDuration.milliseconds, showYYYYMMSS = false)
         val batchUrl = s"/streaming/batch/?id=${job.time.milliseconds}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Optimizes the biggest contributors to serialization overhead in simple queries.

- Properties serialization in Task now walks through the properties and writes to same buffer
  instead of using java serialization writeObject on a separate buffer
- Cloning of properties uses SerializationUtils which is inefficient. Instead added
  Utils.cloneProperties that will clone by walking all its entries (including defaults if requested)
- Separate out WholeStageCodegenExec closure invocation into its own WholeStageCodegenRDD
  for optimal serialization of its components including base RDD and CodeAndComment.
  This RDD also removes the limitation of having a max of only 2 RDDs in inputRDDs().

## How was this patch tested?

snappydata precheckin
