### PR TITLE
[SNAP-1251] Avoid exchange when number of shuffle partitions > child partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -157,6 +157,8 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
     assert(requiredChildOrderings.length == children.length)
 
     // Ensure that the operator's children satisfy their output distribution requirements:
+    // The second boolean parameter in the result is true when a ShuffleExchange
+    // was introduced to satisfy the output distribution.
     val newChildren = children.zip(requiredChildDistributions).map {
       case (child, distribution) if child.outputPartitioning.satisfies(distribution) =>
         (child, false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.internal.SQLConf
  * input partition ordering requirements are met.
  */
 case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
-  private def defaultNumPreShufflePartitions: Int = conf.numShufflePartitions
+  private lazy val defaultNumPreShufflePartitions: Int = conf.numShufflePartitions
 
   private def targetPostShuffleInputSize: Long = conf.targetPostShuffleInputSize
 
@@ -157,14 +157,16 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
     assert(requiredChildOrderings.length == children.length)
 
     // Ensure that the operator's children satisfy their output distribution requirements:
-    children = children.zip(requiredChildDistributions).map {
+    val newChildren = children.zip(requiredChildDistributions).map {
       case (child, distribution) if child.outputPartitioning.satisfies(distribution) =>
-        child
+        (child, false)
       case (child, BroadcastDistribution(mode)) =>
-        BroadcastExchangeExec(mode, child)
+        (BroadcastExchangeExec(mode, child), false)
       case (child, distribution) =>
-        ShuffleExchange(createPartitioning(distribution, defaultNumPreShufflePartitions), child)
+        (ShuffleExchange(createPartitioning(distribution,
+          defaultNumPreShufflePartitions), child), true)
     }
+    children = newChildren.map(_._1)
 
     // If the operator has multiple children and specifies child output distributions (e.g. join),
     // then the children's output partitionings must be compatible:
@@ -180,17 +182,14 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
       // First check if the existing partitions of the children all match. This means they are
       // partitioned by the same partitioning into the same number of partitions. In that case,
       // don't try to make them match `defaultPartitions`, just use the existing partitioning.
-      val maxChildrenNumPartitions = children.map(_.outputPartitioning.numPartitions).max
-      val numBuckets = {
-        children.map(child => {
-          if (child.outputPartitioning.isInstanceOf[OrderlessHashPartitioning]) {
-            child.outputPartitioning.asInstanceOf[OrderlessHashPartitioning].numBuckets
-          }
-          else {
-            0
-          }
-        }).reduceLeft(_ max _)
-      }
+      val maxChildrenNumPartitions = math.abs(newChildren.map {
+        case (child, false) => child.outputPartitioning.numPartitions
+        case _ => -defaultNumPreShufflePartitions
+      }.max)
+      val numBuckets = children.map(_.outputPartitioning match {
+        case p: OrderlessHashPartitioning => p.numBuckets
+        case _ => 0
+      }).max
       val useExistingPartitioning = children.zip(requiredChildDistributions).forall {
         case (child, distribution) =>
           child.outputPartitioning.guarantees(


### PR DESCRIPTION
## What changes were proposed in this pull request?

- reason is that shuffle is added first with default shuffle partitions,
  then the child with maximum partitions is selected; now marking children where
  implicit shuffle was introduced then taking max of rest (except if there are no others
      in which case the negative value gets chosen and its abs returns default shuffle partitions)
- second change is to add a optional set of alias columns in OrderlessHashPartitioning
  for expression matching to satisfy partitioning in case it is on an alias for partitioning column
  (helps queries like TPCH Q21 where implicit aliases are introduced to resolve clashes in self-joins);
  data sources can use this to pass projection aliases, if any (only snappydata ones in embedded mode)

## How was this patch tested?

precheckin; TPCH plans checked, NorthWind hydra test

