### PR TITLE
[SNAP-2231] refactor TaskSchedulerImpl

### DIFF
--- a/core/src/main/scala/org/apache/spark/TaskEndReason.scala
+++ b/core/src/main/scala/org/apache/spark/TaskEndReason.scala
@@ -140,7 +140,8 @@ case class ExceptionFailure(
       e: Throwable,
       accumUpdates: Seq[AccumulableInfo],
       preserveCause: Boolean) {
-    this(e.getClass.getName, e.getMessage, e.getStackTrace, Utils.exceptionString(e),
+    this(e.getClass.getName, e.getMessage, e.getStackTrace,
+      if (Utils.dumpStackTrace(e)) Utils.exceptionString(e) else null,
       if (preserveCause) Some(new ThrowableSerializationWrapper(e)) else None, accumUpdates)
   }
 

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -453,7 +453,14 @@ private[spark] class Executor(
           // Attempt to exit cleanly by informing the driver of our failure.
           // If anything goes wrong (or this was a fatal exception), we will delegate to
           // the default uncaught exception handler, which will terminate the Executor.
-          logError(s"Exception in $taskName (TID $taskId)", t)
+          val errorMessage = s"Exception in $taskName (TID $taskId) (SW: t=${t.getClass})"
+          if (Utils.dumpStackTrace(t)) {
+            logError(errorMessage, t)
+          } else if (isTraceEnabled) {
+            logWarning(errorMessage, t)
+          } else {
+            logWarning(errorMessage + ": " + t.toString)
+          }
 
           // Collect latest accumulator values to report back to the driver
           val accums: Seq[AccumulatorV2[_, _]] =

--- a/core/src/main/scala/org/apache/spark/memory/ExecutionMemoryPool.scala
+++ b/core/src/main/scala/org/apache/spark/memory/ExecutionMemoryPool.scala
@@ -56,7 +56,12 @@ private[memory] class ExecutionMemoryPool(
   private val memoryForTask = new mutable.HashMap[Long, Long]()
 
   override def memoryUsed: Long = lock.synchronized {
-    return memoryForTask.values.sum
+    var sum = 0L
+    val iter = memoryForTask.valuesIterator
+    while (iter.hasNext) {
+      sum += iter.next()
+    }
+    return sum
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/memory/StorageMemoryPool.scala
+++ b/core/src/main/scala/org/apache/spark/memory/StorageMemoryPool.scala
@@ -44,7 +44,7 @@ private[memory] class StorageMemoryPool(
   private[this] var _memoryUsed: Long = 0L
 
   override def memoryUsed: Long = lock.synchronized {
-    _memoryUsed
+    return _memoryUsed
   }
 
   private var _memoryStore: MemoryStore = _

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -169,7 +169,7 @@ private[spark] class TaskSchedulerImpl(
     waitBackendReady()
   }
 
-  protected def submitGetTaskSetManager(taskSet: TaskSet): TaskSetManager = {
+  protected def getTaskSetManagerForSubmit(taskSet: TaskSet): TaskSetManager = {
     {
       val manager = createTaskSetManager(taskSet, maxTaskFailures)
       val stage = taskSet.stageId
@@ -191,7 +191,7 @@ private[spark] class TaskSchedulerImpl(
     val tasks = taskSet.tasks
     logInfo("Adding task set " + taskSet.id + " with " + tasks.length + " tasks")
     this.synchronized {
-      val manager = submitGetTaskSetManager(taskSet)
+      val manager = getTaskSetManagerForSubmit(taskSet)
       schedulableBuilder.addTaskSetManager(manager, manager.taskSet.properties)
 
       if (!isLocal && !hasReceivedTask) {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -267,7 +267,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     protected def checkTaskSizeLimit(task: TaskDescription, taskSize: Int): Boolean = {
       if (taskSize > maxRpcMessageSize) {
-        scheduler.taskIdToTaskSetManager.get(task.taskId).foreach { taskSetMgr =>
+        scheduler.getTaskSetManager(task.taskId).foreach { taskSetMgr =>
           try {
             var msg = "Serialized task %s:%d was %d bytes, which exceeds max allowed: " +
                 "spark.rpc.message.maxSize (%d bytes). Consider increasing " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

- refactored TaskSchedulerImpl a bit and made field/methods protected
  to allow overriding by child classes
- change a couple of more pool calls causing boxing/unboxing
- avoid stack trace dumps for some SQLExceptions like syntax errors, auth errors, constraint
  violations (same list as in snappy-store GfxdHeaderPrintWriterImpl.printStackTrace)

## How was this patch tested?

snappy-spark precheckin