### PR TITLE
[SNAPPY-2511] initialize SortMergeJoin build-side scanner lazily

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -613,7 +613,7 @@ private[joins] class SortMergeJoinScanner(
   private[this] val bufferedMatches: ArrayBuffer[InternalRow] = new ArrayBuffer[InternalRow]
 
   // Initialization (note: do _not_ want to advance streamed here).
-  advancedBufferedToRowWithNullFreeJoinKey()
+  private[this] lazy val initBuffered = advancedBufferedToRowWithNullFreeJoinKey()
 
   // --- Public methods ---------------------------------------------------------------------------
 
@@ -724,6 +724,7 @@ private[joins] class SortMergeJoinScanner(
     if (streamedIter.advanceNext()) {
       streamedRow = streamedIter.getRow
       streamedRowKey = streamedKeyGenerator(streamedRow)
+      initBuffered
       true
     } else {
       streamedRow = null


### PR DESCRIPTION
Avoid sorting the build side of SortMergeJoin if the streaming side is empty.

## What changes were proposed in this pull request?

This already works that way for inner joins with code generation where the build side
is initialized on first call from processNext (using the generated variable
   "needToSort" in SortExec). This change also enables the behaviour for non-inner
join queries that use "SortMergeJoinScanner" that instantiates build-side upfront.

## How was this patch tested?

Spark and SnappyData test suite