### PR TITLE
Cube Query issue

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.metric.SQLMetrics
-import org.apache.spark.sql.internal.SQLConf.MAX_CASES_BRANCHES
 
 /**
  * Apply all of the GroupExpressions to every input row, hence we will get
@@ -46,11 +45,6 @@ case class ExpandExec(
   // The GroupExpressions can output data with arbitrary partitioning, so set it
   // as UNKNOWN partitioning
   override def outputPartitioning: Partitioning = UnknownPartitioning(0)
-
-  override def supportCodegen: Boolean = {
-    logInfo(s"The length of projections are ${projections.length}")
-    projections.length < 1000
-  }
 
   override def references: AttributeSet =
     AttributeSet(projections.flatten.flatMap(_.references))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.internal.SQLConf.MAX_CASES_BRANCHES
 
 /**
  * Apply all of the GroupExpressions to every input row, hence we will get
@@ -45,6 +46,11 @@ case class ExpandExec(
   // The GroupExpressions can output data with arbitrary partitioning, so set it
   // as UNKNOWN partitioning
   override def outputPartitioning: Partitioning = UnknownPartitioning(0)
+
+  override def supportCodegen: Boolean = {
+    logInfo(s"The length of projections are ${projections.length}")
+    projections.length < 1000
+  }
 
   override def references: AttributeSet =
     AttributeSet(projections.flatten.flatMap(_.references))
@@ -177,9 +183,10 @@ case class ExpandExec(
       }
 
       s"""
-         |case $row:
-         |  ${updateCode.trim}
-         |  break;
+         |case $row: {
+         |    ${updateCode.trim}
+         |    break;
+         |  }
        """.stripMargin
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Put the code of case block in {} to reduce the scope. This helps janino compiler reducing memory pressure.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
