### PR TITLE
Update oracle ojdbc6 versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ allprojects {
   repositories {
     mavenCentral()
     maven { url 'http://repository.apache.org/snapshots' }
+    maven { url 'https://repo.hortonworks.com/content/repositories/releases/' }
   }
 
   apply plugin: 'java'
@@ -70,7 +71,7 @@ allprojects {
     mockitoVersion = '1.10.19'
     javaxServletVersion = '3.1.0'
     guavaVersion = '14.0.1'
-    hiveVersion = '1.2.1.spark2'
+    hiveVersion = '1.21.2.3.1.2.2-1'
     chillVersion = '0.8.5'
     kryoVersion = '4.0.2'
     nettyVersion = '3.10.6.Final'
@@ -118,7 +119,7 @@ allprojects {
     dockerClientVersion = '8.14.5'
     mysqlVersion = '8.0.13'
     postgresqlVersion = '42.2.5'
-    ojdbc6Version = '11.2.0.1.0'
+    ojdbc6Version = '11.2.0.4'
     zookeeperVersion = '3.4.13'
     jets3tVersion = '0.9.4'
     roaringBitmapVersion = '0.6.66'

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ allprojects {
   repositories {
     mavenCentral()
     maven { url 'http://repository.apache.org/snapshots' }
-    maven { url 'https://repo.hortonworks.com/content/repositories/releases/' }
   }
 
   apply plugin: 'java'
@@ -71,7 +70,7 @@ allprojects {
     mockitoVersion = '1.10.19'
     javaxServletVersion = '3.1.0'
     guavaVersion = '14.0.1'
-    hiveVersion = '1.21.2.3.1.2.2-1'
+    hiveVersion = '1.2.1.spark2'
     chillVersion = '0.8.5'
     kryoVersion = '4.0.2'
     nettyVersion = '3.10.6.Final'

--- a/external/docker-integration-tests/build.gradle
+++ b/external/docker-integration-tests/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   testCompile group: 'org.apache.httpcomponents', name: 'httpcore', version: httpCoreVersion
   testCompile group: 'mysql', name: 'mysql-connector-java', version: mysqlVersion
   testCompile group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
-  testCompile group: 'com.oracle', name: 'ojdbc6', version: ojdbc6Version
+  testCompile group: 'com.oracle.database.jdbc', name: 'ojdbc6', version: ojdbc6Version
   testCompile group: 'com.sun.jersey', name: 'jersey-server', version: sunJerseyVersion
   testCompile group: 'com.sun.jersey', name: 'jersey-core', version: sunJerseyVersion
   testCompile group: 'com.sun.jersey', name: 'jersey-servlet', version: sunJerseyVersion

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -723,7 +723,7 @@ class SparkSession private(
     this.streams.addListener(listener)
     sessionState.registerStreamingQueryListener(listener)
     if (sparkContext.ui.isDefined) {
-      // logInfo("Updating Web UI to add structure streaming tab.")
+      logDebug("Updating Web UI to add structure streaming tab.")
       sparkContext.ui.foreach(ui => {
         var structStreamTabPresent: Boolean = false
         val tabsList = ui.getTabs
@@ -732,7 +732,7 @@ class SparkSession private(
           // Check if Structure Streaming Tab is present or not
           if (tab.prefix.equalsIgnoreCase("structuredstreaming")) {
             structStreamTabPresent = true
-            // logInfo("Structure Streaming UI Tab is already present.")
+            logDebug("Structure Streaming UI Tab is already present.")
           }
         })
         // Add Structure Streaming Tab, iff not present
@@ -744,7 +744,7 @@ class SparkSession private(
           new SnappyStreamingTab(ui, listener)
         }
       })
-      logTrace("Updating Web UI to add structured streaming tab is Done.")
+      logDebug("Updating Web UI to add structured streaming tab is Done.")
     }
   }
 


### PR DESCRIPTION
Hive version is slightly newer than the one in other open PR. ojbc6 is updated to a non-deprecated version actually available in maven central.

Also added back logging for structured streaming tab with logDebug so users can turn it on if required.